### PR TITLE
Update for PHP7 compatibility

### DIFF
--- a/lib/functions/template-tags.php
+++ b/lib/functions/template-tags.php
@@ -273,7 +273,7 @@ function cherry_get_related_post_list( $args = array(), $post_id = null ) {
 		}
 
 		if ( empty( $tax_query ) ) {
-			break;
+			return;		//Changed 'break' to 'return' for PHP7
 		}
 
 		if ( 1 < count( $tax_query ) ) {
@@ -307,7 +307,7 @@ function cherry_get_related_post_list( $args = array(), $post_id = null ) {
 		preg_match( '/^(\w+)\W+(\w+)/i', get_the_title( $post_id ), $matches );
 
 		if ( ! is_array( $matches ) ) {
-			break;
+			return;		//Changed 'break' to 'return' for PHP7
 		}
 
 		$search_request = '';


### PR DESCRIPTION
"PHP message: PHP Fatal error:  'break' not in the 'loop' or 'switch' context" occurs when using 'break' in lines 276 and 310.

Changed 'break' to 'return'
