### PR TITLE
BUG: get_current_file doesn't work with multi-site installs

### DIFF
--- a/lib/admin/ui-elements/ui-ace-editor/ui-ace-editor.php
+++ b/lib/admin/ui-elements/ui-ace-editor/ui-ace-editor.php
@@ -70,8 +70,8 @@ if ( ! class_exists( 'UI_Ace_Editor' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-background/ui-background.php
+++ b/lib/admin/ui-elements/ui-background/ui-background.php
@@ -164,8 +164,8 @@ if ( ! class_exists( 'UI_Background' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-checkbox/ui-checkbox.php
+++ b/lib/admin/ui-elements/ui-checkbox/ui-checkbox.php
@@ -122,8 +122,8 @@ if ( ! class_exists( 'UI_Checkbox' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-colorpicker/ui-colorpicker.php
+++ b/lib/admin/ui-elements/ui-colorpicker/ui-colorpicker.php
@@ -66,8 +66,8 @@ if ( ! class_exists( 'UI_Colorpicker' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-layout-editor/ui-layout-editor.php
+++ b/lib/admin/ui-elements/ui-layout-editor/ui-layout-editor.php
@@ -185,8 +185,8 @@ if ( ! class_exists( 'UI_Layout_Editor' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-media/ui-media.php
+++ b/lib/admin/ui-elements/ui-media/ui-media.php
@@ -133,8 +133,8 @@ if ( ! class_exists( 'UI_Media' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-radio/ui-radio.php
+++ b/lib/admin/ui-elements/ui-radio/ui-radio.php
@@ -101,8 +101,8 @@ if ( ! class_exists( 'UI_Radio' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-range-slider/ui-range-slider.php
+++ b/lib/admin/ui-elements/ui-range-slider/ui-range-slider.php
@@ -102,8 +102,8 @@ if ( ! class_exists( 'UI_Range_Slider' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-repeater/ui-repeater.php
+++ b/lib/admin/ui-elements/ui-repeater/ui-repeater.php
@@ -133,12 +133,13 @@ if ( ! class_exists( 'UI_Repeater' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;
 		}
+
 		/**
 		 * Enqueue javascript and stylesheet UI_Repeater
 		 *

--- a/lib/admin/ui-elements/ui-select/ui-select.php
+++ b/lib/admin/ui-elements/ui-select/ui-select.php
@@ -131,8 +131,8 @@ if ( ! class_exists( 'UI_Select' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-slider/ui-slider.php
+++ b/lib/admin/ui-elements/ui-slider/ui-slider.php
@@ -86,8 +86,8 @@ if ( ! class_exists( 'UI_Slider' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-static-area-editor/ui-static-area-editor.php
+++ b/lib/admin/ui-elements/ui-static-area-editor/ui-static-area-editor.php
@@ -646,8 +646,8 @@ if ( ! class_exists( 'UI_Static_Area_Editor' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-stepper/ui-stepper.php
+++ b/lib/admin/ui-elements/ui-stepper/ui-stepper.php
@@ -70,8 +70,8 @@ if ( ! class_exists( 'UI_Stepper' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-switcher/ui-switcher.php
+++ b/lib/admin/ui-elements/ui-switcher/ui-switcher.php
@@ -77,8 +77,8 @@ if ( ! class_exists( 'UI_Switcher' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-text/ui-text.php
+++ b/lib/admin/ui-elements/ui-text/ui-text.php
@@ -63,16 +63,9 @@ if ( ! class_exists( 'UI_Text' ) ) {
 		 * @since  4.0.0
 		 */
 		public static function get_current_file_url() {
-			/*$abs_path = str_replace('/', '\\', ABSPATH);
 			$assets_url = dirname( __FILE__ );
-			$assets_url = str_replace( $abs_path, '', $assets_url );
-			$assets_url = site_url().'/'.$assets_url;
-			$assets_url = str_replace( '\\', '/', $assets_url );*/
-
-
-			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-textarea/ui-textarea.php
+++ b/lib/admin/ui-elements/ui-textarea/ui-textarea.php
@@ -65,8 +65,8 @@ if ( ! class_exists( 'UI_Textarea' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-tooltip/ui-tooltip.php
+++ b/lib/admin/ui-elements/ui-tooltip/ui-tooltip.php
@@ -73,8 +73,8 @@ if ( ! class_exists( 'UI_Tooltip' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-typography/ui-typography.php
+++ b/lib/admin/ui-elements/ui-typography/ui-typography.php
@@ -514,8 +514,8 @@ if ( ! class_exists( 'UI_Typography' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;

--- a/lib/admin/ui-elements/ui-webfont/ui-webfont.php
+++ b/lib/admin/ui-elements/ui-webfont/ui-webfont.php
@@ -339,8 +339,8 @@ if ( ! class_exists( 'UI_Webfont' ) ) {
 		 */
 		public static function get_current_file_url() {
 			$assets_url = dirname( __FILE__ );
-			$site_url = site_url();
-			$assets_url = str_replace( untrailingslashit( ABSPATH ), $site_url, $assets_url );
+			$site_url = site_url() . WP_CONTENT_URL;
+			$assets_url = str_replace( untrailingslashit( WP_CONTENT_DIR ), $site_url, $assets_url );
 			$assets_url = str_replace( '\\', '/', $assets_url );
 
 			return $assets_url;


### PR DESCRIPTION
The function (repeated way too many times) shouldn't use ABSPATH as it
doesn't work on multi-site installs. It should be replacing
WP_CONTENT_DIR with WP_CONTENT_URL.
