### PR TITLE
Fix Google Font URL

### DIFF
--- a/lib/classes/class-cherry-google-fonts-enqueue.php
+++ b/lib/classes/class-cherry-google-fonts-enqueue.php
@@ -128,20 +128,20 @@ class cherry_enqueue_fonts {
 
 		foreach ( $this->fonts_data as $family => $data ) {
 			$styles = implode( ',', array_unique( $data['style'] ) );
-			$font_families[] = $family . ':' . $styles;
-			$subsets = array_merge( $subsets, $data['character'] );
+			$font_families[] = urlencode($family) . ':' . $styles;
+                        $subsets = array_merge( $subsets, array_filter($data['character']));
+                        
 		}
 
-		$subsets = array_unique( $subsets );
-
+		$subsets = array_unique( $subsets );                
 		$query_args = array(
-			'family' => urlencode( implode( '|', $font_families ) ),
-			'subset' => urlencode( implode( ',', $subsets ) ),
+			'family' => implode( '|', $font_families ),
+			'subset' => implode( ',', $subsets ),
 		);
 
-		$fonts_url = add_query_arg( $query_args, $this->fonts_host );
-
-		return $fonts_url;
+                $fonts_url = add_query_arg( $query_args, $this->fonts_host );
+                return trim($fonts_url);
+  
 	}
 
 	/**


### PR DESCRIPTION
Fixed a bad encoded URL that resulted in a **Status Code: 400 Bad Request** error when calling Google Font stylesheet